### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 # mkdir /volume1/docker/appdata/sonarr
   sonarr:
     container_name: sonarr
-    image: ghcr.io/hotio/sonarr:v4
+    image: ghcr.io/hotio/sonarr:release
     restart: unless-stopped
     logging:
       driver: json-file


### PR DESCRIPTION
Hotio has pushed the v4 of sonarr to the `release` tag. Updated the template to reflect this.

