### PR TITLE
faze out cr.hotio.dev

### DIFF
--- a/templates/bazarr.yml
+++ b/templates/bazarr.yml
@@ -5,7 +5,7 @@
 #
   bazarr:
     container_name: bazarr
-    image: cr.hotio.dev/hotio/bazarr:nightly
+    image: hotio/bazarr:nightly
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/jellyfin.yml
+++ b/templates/jellyfin.yml
@@ -5,7 +5,7 @@
 #
   jellyfin:
     container_name: jellyfin
-    image: cr.hotio.dev/hotio/jellyfin
+    image: hotio/jellyfin
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/lidarr.yml
+++ b/templates/lidarr.yml
@@ -5,7 +5,7 @@
 #
   lidarr:
     container_name: lidarr
-    image: cr.hotio.dev/hotio/lidarr:latest
+    image: hotio/lidarr:latest
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/overseerr.yml
+++ b/templates/overseerr.yml
@@ -5,7 +5,7 @@
 #
   overseerr:
     container_name: overseerr
-    image: cr.hotio.dev/hotio/overseerr
+    image: hotio/overseerr
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/plex.yml
+++ b/templates/plex.yml
@@ -5,7 +5,7 @@
 #
   plex:
     container_name: plex
-    image: cr.hotio.dev/hotio/plex
+    image: hotio/plex
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/prowlarr.yml
+++ b/templates/prowlarr.yml
@@ -5,7 +5,7 @@
 #
   prowlarr:
     container_name: prowlarr
-    image: cr.hotio.dev/hotio/prowlarr:testing
+    image: hotio/prowlarr:testing
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/qbittorrent.yml
+++ b/templates/qbittorrent.yml
@@ -20,7 +20,7 @@
 
   qbittorrent:
     container_name: qbittorrent
-    image: cr.hotio.dev/hotio/qbittorrent:legacy
+    image: hotio/qbittorrent:legacy
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/radarr.yml
+++ b/templates/radarr.yml
@@ -5,7 +5,7 @@
 #
   radarr:
     container_name: radarr
-    image: cr.hotio.dev/hotio/radarr:latest
+    image: hotio/radarr:latest
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/readarr.yml
+++ b/templates/readarr.yml
@@ -5,7 +5,7 @@
 #
   readarr:
     container_name: readarr
-    image: cr.hotio.dev/hotio/readarr
+    image: hotio/readarr
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/sabnzbd.yml
+++ b/templates/sabnzbd.yml
@@ -5,7 +5,7 @@
 #
   sabnzbd:
     container_name: sabnzbd
-    image: cr.hotio.dev/hotio/sabnzbd:latest
+    image: hotio/sabnzbd:latest
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/sonarr.yml
+++ b/templates/sonarr.yml
@@ -5,7 +5,7 @@
 #
   sonarr:
     container_name: sonarr
-    image: cr.hotio.dev/hotio/sonarr:nightly
+    image: hotio/sonarr:nightly
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/tautulli.yml
+++ b/templates/tautulli.yml
@@ -5,7 +5,7 @@
 #
   tautulli:
     container_name: tautulli
-    image: cr.hotio.dev/hotio/tautulli
+    image: hotio/tautulli
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/unpackerr.yml
+++ b/templates/unpackerr.yml
@@ -5,7 +5,7 @@
 #
   unpackerr:
     container_name: unpackerr
-    image: cr.hotio.dev/hotio/unpackerr:release
+    image: hotio/unpackerr:release
     restart: unless-stopped
     logging:
       driver: json-file


### PR DESCRIPTION
# Pull request

**Purpose**
As per Hotios announcement cr.hotio.dev is no longer in use

**Approach**
Changing the images to docker hub, as not all might be available on Github.

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x ] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
