### PR TITLE
Remove unnecessary pre-up from qbittorrent template

### DIFF
--- a/templates/qbittorrent.yml
+++ b/templates/qbittorrent.yml
@@ -9,14 +9,13 @@
 # Edit the wg0.conf, change AllowedIPs to 0.0.0.0/1,128.0.0.0/1
 # Remove the `DNS = 1.1.1.1` line from the wg0.conf
 # Remove any preexisting preup or postup from your wg0.conf file
-# Add this preup to your wg0 (read the instructions): https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/script/PreUp.sh
 #
 # If you are getting a "Failed to open '/dev/net/tun'" error, run the commands below.
 # 1 - sudo curl -sL https://raw.githubusercontent.com/TRaSH-/Guides-Synology-Templates/main/script/tun.service -o "/etc/systemd/system/tun.service"
 # 2"- sudo systemctl enable /etc/systemd/system/tun.service
 # 3 - sudo systemctl start tun
 # Check if running with - sudo systemctl status tun
-# recreate the container with - sudo docker-compose up --force-recreate qbittorrent
+# recreate the container with - sudo docker-compose up -d --force-recreate qbittorrent
 
   qbittorrent:
     container_name: qbittorrent


### PR DESCRIPTION
# Pull request

**Purpose**
Per Discord, the pre-up breaks qbittorrent completely on Synology now.

**Approach**
This fixes a breaking bug that causes qbittorrent to crash over and over again.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you add a new template for a application take a look at [DockSTARTer](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps) for examples being I used them as base for the others templates

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
