### PR TITLE
feat(prowlarr): add prowlarr

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -81,6 +81,35 @@ services:
       - ${DOCKERCONFDIR}/bazarr:/config
       - ${DOCKERSTORAGEDIR}/media:/data/media
 
+# Prowlarr - https://hotio.dev/containers/prowlarr/
+#
+# Don't forget to create the directory, change chown command if needed (the user:group part)
+# sudo -u docker mkdir -m=00775 /volume1/docker/appdata/prowlarr
+#
+  prowlarr:
+    container_name: prowlarr
+    image: hotio/prowlarr:testing
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    labels:
+      - org.hotio.pullio.update=${PULLIO_UPDATE}
+      - org.hotio.pullio.notify=${PULLIO_NOTIFY}
+      - org.hotio.pullio.discord.webhook=${PULLIO_DISCORD_WEBHOOK}
+    ports:
+      - 9696:9696
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+      - UMASK=002
+      - ARGS=
+    volumes:
+      - ${DOCKERCONFDIR}/prowlarr:/config:rw
+
 # Plex - https://hotio.dev/containers/plex/
 # mkdir -p /volume1/docker/appdata/plex
 # Also please read the extra info => https://trash-guides.info/Hardlinks/How-to-setup-for/Synology/#appdata


### PR DESCRIPTION
# Pull request

**Purpose**
The [Synology guide](https://trash-guides.info/Hardlinks/How-to-setup-for/Synology/) says

> This docker-compose file will have the following docker containers included.
> 
>     - Radarr
>     - Sonarr
>     - Bazarr (Subtitle searcher and downloader)
>     - Plex
>     - Prowlarr (indexer/tracker manager)

But Prowlarr wasn't in the main `docker-compose.yml`. This PR adds the Prowlarr from [here](https://github.com/TRaSH-Guides/Synology-Templates/blob/main/templates/prowlarr.yml) to the docker compose.

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
