### PR TITLE
fix(jellyfin): add quicksync video check

### DIFF
--- a/script/trash_syno_installer.sh
+++ b/script/trash_syno_installer.sh
@@ -717,14 +717,15 @@ while true; do
             for options in "${selected_options[@]}"; do
                 mkdir -p "${docker_conf_dir}/appdata/${options}"
                 get_app_compose "${options}"
-                [[ "${options}" == 'plex' ]] && plex_installed="yes" 
+                [[ "${options}" == 'plex' ]] && plex_installed="yes"
+		[[ "${options}" == 'jellyfin' ]] && jellyfin_installed="yes" 
                 [[ "${options}" == 'qbittorrent' ]] && qbit_installed="yes" && mkdir -p "${docker_data_dir}"/torrents/{tv,movies}
                 [[ "${options}" == 'radarr' ]] && mkdir -p "${docker_data_dir}/media/movies"
                 [[ "${options}" == 'sonarr' ]] && mkdir -p "${docker_data_dir}/media/tv"
                 [[ "${options}" =~ ^(sabnzbd|nzbget)$ ]] && mkdir -p "${docker_data_dir}"/usenet/complete/{tv,movies}
             done
 
-            if [[ "${plex_installed}" == "yes" ]]; then
+            if [[ "${plex_installed}" == "yes" || "${jellyfin_installed}" == "yes" ]]; then
                 #check for quick sync
                 if [[ -d "$qsv" ]]; then
                     ### Do nothing if $qsv exists.


### PR DESCRIPTION
Added the Quicksync check for when Jellyfin is selected as media server.

# Pull request

**Purpose**
Jellyfin template was added as media server, needed quicksync video check to enable the hardware transcoding.

**Approach**
n/a

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.


**Requirements**
Check all boxes as they are completed

- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
