### PR TITLE
docs(synology-plex): update note regarding Plex advertise url port

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -27,7 +27,7 @@ PLEX_CLAIM_TOKEN=claim-xxxxxxxxxxxxxxxxxxxx
 # If you are a Plex Pass subscriber, you can enable the install of beta builds <true|false>
 PLEX_BETA_INSTALL=true
 
-# Replace http://192.168.x.x:32400 with the IP of your server/nas.
+# Replace IP in http://192.168.x.x:32400 with the IP of your server/nas, don't change the port! Unless you specifically changed the default port.
 # This is useful to aid your local clients in discovering your plex server when running in the bridge network mode.
 PLEX_ADVERTISE_URL="http://192.168.x.x:32400"
 


### PR DESCRIPTION
Updated comment about Plex advertise URL.

# Pull request

**Purpose**
Updated comment about Plex advertise URL, so people don't mess with the port unless they know what they are doing.

**Approach**
n/a

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
