### PR TITLE
docs(authelia): fix authelia link

### DIFF
--- a/templates/authelia.yml
+++ b/templates/authelia.yml
@@ -1,4 +1,4 @@
-# Authelia - https://www.authelia.com/docs/
+# Authelia - https://www.authelia.com
 #
 # Don't forget to create the directory, change the -u value if needed (the created user)
 # sudo -u docker mkdir -m=00775 /volume1/docker/appdata/authelia


### PR DESCRIPTION
# Pull request

**Purpose**
The current authelia template links to https://authelia.com/docs/ which leads to a 404 page.
I've updated the url to link to the home page instead.

**Approach**
remove `/docs/` from the url

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you add a new template for a application take a look at [DockSTARTer](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps) for examples being I used them as base for the others templates

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).