### PR TITLE
Update hotio images to use GHCR instead of Docker Hub

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -88,7 +88,7 @@ services:
 #
   prowlarr:
     container_name: prowlarr
-    image: hotio/prowlarr:testing
+    image: ghcr.io/hotio/prowlarr:testing
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/jellyfin.yml
+++ b/templates/jellyfin.yml
@@ -5,7 +5,7 @@
 #
   jellyfin:
     container_name: jellyfin
-    image: hotio/jellyfin
+    image: ghcr.io/hotio/jellyfin
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/jellyseerr.yml
+++ b/templates/jellyseerr.yml
@@ -5,7 +5,7 @@
 #
   jellyseerr:
     container_name: jellyseerr
-    image: hotio/jellyseerr
+    image: ghcr.io/hotio/jellyseerr
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/lidarr.yml
+++ b/templates/lidarr.yml
@@ -5,7 +5,7 @@
 #
   lidarr:
     container_name: lidarr
-    image: hotio/lidarr:latest
+    image: ghcr.io/hotio/lidarr:latest
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/overseerr.yml
+++ b/templates/overseerr.yml
@@ -5,7 +5,7 @@
 #
   overseerr:
     container_name: overseerr
-    image: hotio/overseerr
+    image: ghcr.io/hotio/overseerr
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/plex.yml
+++ b/templates/plex.yml
@@ -6,7 +6,7 @@
 
   plex:
     container_name: plex
-    image: hotio/plex
+    image: ghcr.io/hotio/plex
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/prowlarr.yml
+++ b/templates/prowlarr.yml
@@ -5,7 +5,7 @@
 #
   prowlarr:
     container_name: prowlarr
-    image: hotio/prowlarr:testing
+    image: ghcr.io/hotio/prowlarr:testing
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/qbitmanage.yml
+++ b/templates/qbitmanage.yml
@@ -1,4 +1,4 @@
-# qbit_manage - https://hub.docker.com/r/hotio/qbitmanage
+# qbit_manage - https://hotio.dev/containers/qbitmanage/
 #
 # Don't forget to create the directory, change chown command if needed (the user:group part)
 # sudo -u docker mkdir -m=00775 /volume1/docker/appdata/qbitmanage

--- a/templates/qbittorrent.yml
+++ b/templates/qbittorrent.yml
@@ -21,7 +21,7 @@
 
   qbittorrent:
     container_name: qbittorrent
-    image: hotio/qbittorrent:latest
+    image: ghcr.io/hotio/qbittorrent:latest
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/radarr.yml
+++ b/templates/radarr.yml
@@ -5,7 +5,7 @@
 #
   radarr:
     container_name: radarr
-    image: hotio/radarr:latest
+    image: ghcr.io/hotio/radarr:latest
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/tautulli.yml
+++ b/templates/tautulli.yml
@@ -5,7 +5,7 @@
 #
   tautulli:
     container_name: tautulli
-    image: hotio/tautulli
+    image: ghcr.io/hotio/tautulli
     restart: unless-stopped
     logging:
       driver: json-file

--- a/templates/unpackerr.yml
+++ b/templates/unpackerr.yml
@@ -1,11 +1,11 @@
-# unpackerr - https://hub.docker.com/r/hotio/unpackerr
+# unpackerr - https://hotio.dev/containers/unpackerr/
 #
 # Don't forget to create the directory
 # sudo mkdir -m=00775 /volume1/docker/appdata/unpackerr
 #
   unpackerr:
     container_name: unpackerr
-    image: hotio/unpackerr:release
+    image: ghcr.io/hotio/unpackerr:release
     restart: unless-stopped
     logging:
       driver: json-file


### PR DESCRIPTION
Updates all hotio container images from Docker Hub to GitHub Container Registry (GHCR) for better reliability and performance.

## Changes
- Updated all `hotio/` image references to `ghcr.io/hotio/` 
- Updated documentation links from Docker Hub to hotio.dev
- Affects 11 template files and the main docker-compose.yml

This aligns with hotio's recommendation to use GHCR as the primary registry and ensures users get the most up-to-date images with better download speeds.